### PR TITLE
Add a new way to compare version

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,53 @@
+package version
+
+import (
+	"regexp"
+	"strings"
+)
+
+var onlyNumberRegExp = regexp.MustCompile(`[^0-9]`)
+
+// if a > b return true
+func Compare(a, b string) bool {
+	listA := strings.Split(a, ".")
+	listB := strings.Split(b, ".")
+
+	// adding 0 to the shorter list
+	if len(listA) > len(listB) {
+		for i := 0; i < len(listA)-len(listB); i++ {
+			listB = append(listB, "0")
+		}
+	} else {
+		for i := 0; i < len(listB)-len(listA); i++ {
+			listA = append(listA, "0")
+		}
+	}
+
+	// make sure each element is a number
+	for i := 0; i < len(listA); i++ {
+		listA[i] = onlyNumberRegExp.ReplaceAllString(listA[i], "")
+	}
+
+	for i := 0; i < len(listB); i++ {
+		listB[i] = onlyNumberRegExp.ReplaceAllString(listB[i], "")
+	}
+
+	// adding leading 0 to each element
+	for i := 0; i < len(listA); i++ {
+		if len(listA[i]) < len(listB[i]) {
+			listA[i] = strings.Repeat("0", len(listB[i])-len(listA[i])) + listA[i]
+		} else if len(listA[i]) > len(listB[i]) {
+			listB[i] = strings.Repeat("0", len(listA[i])-len(listB[i])) + listB[i]
+		}
+	}
+
+	for i := 0; i < len(listA); i++ {
+		if listA[i] == listB[i] {
+			continue
+		}
+
+		return listA[i] > listB[i]
+	}
+
+	return len(listA) > len(listB)
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,27 @@
+package version_test
+
+import (
+	"testing"
+
+	"selfupdate.blockthrough.com/pkg/version"
+)
+
+func TestVersionCompare(t *testing.T) {
+	tests := []struct {
+		a    string
+		b    string
+		want bool
+	}{
+		{"1.0.0", "1.0.0", false},
+		{"1.0.0", "1.0.1", false},
+		{"1.9.0", "1.10.0", false},
+		{"1.10.0", "1.9.0", true},
+	}
+
+	for _, tt := range tests {
+		got := version.Compare(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("%s > %s = %v; want %v", tt.a, tt.b, got, tt)
+		}
+	}
+}


### PR DESCRIPTION
The current method we're using for version comparison is flawed because it relies on simple string comparison, which leads to incorrect results. For example:

Version 1.9.0 should be smaller than 1.10.0, but with string comparison, 1.9.0 is treated as larger than 1.10.0.
While I considered using semantic versioning, I opted not to include it in this library to minimize external dependencies.

However, I have provided a mechanism for users of this library to override the default implementation, allowing them to use their preferred version comparison method if desired.